### PR TITLE
Add dataset manager CLI

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 # Ignore dataset storage file
 datasets.json
+__pycache__/

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Open Research Repository
 
-This project provides a simple command-line tool for managing links to open datasets. Researchers can add, list, and remove dataset entries stored in a local JSON file.
+This project provides a simple command-line tool for managing links to open datasets. Researchers can add, list, update, search, and remove dataset entries stored in a local JSON file.
 
 ## Usage
 
@@ -13,4 +13,10 @@ python dataset_manager.py list
 
 # Remove a dataset
 python dataset_manager.py remove "Dataset Name"
+
+# Update a dataset
+python dataset_manager.py update "Dataset Name" --link "http://new.link" --description "New info"
+
+# Search for datasets
+python dataset_manager.py search "keyword"
 ```

--- a/dataset_manager.py
+++ b/dataset_manager.py
@@ -32,7 +32,7 @@ def list_datasets():
     if not datasets:
         print('No datasets found.')
         return
-    for d in datasets:
+    for d in sorted(datasets, key=lambda x: x['name'].lower()):
         print(f"- {d['name']}: {d['link']}\n  {d['description']}")
 
 
@@ -44,6 +44,30 @@ def remove_dataset(name):
         return
     save_datasets(new_datasets)
     print(f"Removed dataset '{name}'.")
+
+
+def update_dataset(name, link=None, description=None):
+    datasets = load_datasets()
+    for d in datasets:
+        if d['name'] == name:
+            if link is not None:
+                d['link'] = link
+            if description is not None:
+                d['description'] = description
+            save_datasets(datasets)
+            print(f"Updated dataset '{name}'.")
+            return
+    print(f"Dataset '{name}' not found.")
+
+
+def search_datasets(keyword):
+    datasets = load_datasets()
+    results = [d for d in datasets if keyword.lower() in d['name'].lower()]
+    if not results:
+        print('No matching datasets found.')
+        return
+    for d in sorted(results, key=lambda x: x['name'].lower()):
+        print(f"- {d['name']}: {d['link']}\n  {d['description']}")
 
 
 def parse_args():
@@ -60,6 +84,14 @@ def parse_args():
     rm_p = subparsers.add_parser('remove', help='Remove a dataset')
     rm_p.add_argument('name')
 
+    up_p = subparsers.add_parser('update', help='Update an existing dataset')
+    up_p.add_argument('name')
+    up_p.add_argument('--link', help='New link')
+    up_p.add_argument('--description', help='New description')
+
+    search_p = subparsers.add_parser('search', help='Search datasets by name')
+    search_p.add_argument('keyword')
+
     return parser.parse_args()
 
 
@@ -71,6 +103,10 @@ def main():
         list_datasets()
     elif args.command == 'remove':
         remove_dataset(args.name)
+    elif args.command == 'update':
+        update_dataset(args.name, args.link, args.description)
+    elif args.command == 'search':
+        search_datasets(args.keyword)
     else:
         print('No command provided. Use --help for usage information.')
 


### PR DESCRIPTION
## Summary
- add a simple dataset manager CLI that stores dataset metadata in JSON
- update README with project description and usage examples
- ignore generated `datasets.json` file

## Testing
- `python3 dataset_manager.py --help`
- `python3 dataset_manager.py list`
- `python3 dataset_manager.py add "Sample" "http://example.com" "Example dataset"`
- `python3 dataset_manager.py remove "Sample"`

------
https://chatgpt.com/codex/tasks/task_e_68530eae7f308322b0e215a5aeb9432a