### PR TITLE
Implement sample bot engine with adapters

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+node_modules
+package-lock.json
+dist

--- a/package.json
+++ b/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "bot",
+  "version": "1.0.0",
+  "type": "module",
+  "main": "dist/index.js",
+  "scripts": {
+    "build": "tsc",
+    "start": "node dist/index.js"
+  },
+  "dependencies": {
+    "axios": "^1.6.7",
+    "yaml": "^2.3.0"
+  },
+  "devDependencies": {
+    "@types/node": "^24.0.3",
+    "typescript": "^5.3.3"
+  }
+}

--- a/src/bot/core/engine.ts
+++ b/src/bot/core/engine.ts
@@ -1,0 +1,64 @@
+import fs from 'fs';
+import path from 'path';
+import yaml from 'yaml';
+import axios from 'axios';
+
+interface IntentConfig {
+  phrases: string[];
+}
+
+interface FlowConfig {
+  intents: Record<string, IntentConfig>;
+}
+
+type Adapter = () => Promise<string>;
+
+async function fetchWeather(): Promise<string> {
+  const lat = 40.71; // New York City latitude
+  const lon = -74.01; // New York City longitude
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${lat}&longitude=${lon}&current_weather=true`;
+  const response = await axios.get(url);
+  const temp = response.data.current_weather?.temperature;
+  return `The current temperature is ${temp}\u00B0C.`;
+}
+
+async function fetchJoke(): Promise<string> {
+  const url = 'https://v2.jokeapi.dev/joke/Any?type=single';
+  const response = await axios.get(url);
+  return response.data.joke;
+}
+
+export class Engine {
+  private flows: FlowConfig;
+  private adapters: Record<string, Adapter>;
+
+  constructor(flowFile: string) {
+    const filePath = path.resolve(flowFile);
+    const content = fs.readFileSync(filePath, 'utf-8');
+    this.flows = yaml.parse(content);
+
+    this.adapters = {
+      weather: fetchWeather,
+      joke: fetchJoke,
+      fallback: async () => "Sorry, I didn't understand that."
+    };
+  }
+
+  async handle(text: string): Promise<string> {
+    const lower = text.toLowerCase();
+
+    for (const [intent, cfg] of Object.entries(this.flows.intents)) {
+      if (intent === 'fallback') continue;
+      for (const phrase of cfg.phrases) {
+        if (lower.includes(phrase.toLowerCase())) {
+          const adapter = this.adapters[intent];
+          if (adapter) {
+            return adapter();
+          }
+        }
+      }
+    }
+
+    return this.adapters['fallback']();
+  }
+}

--- a/src/bot/flows/example.yaml
+++ b/src/bot/flows/example.yaml
@@ -1,0 +1,11 @@
+intents:
+  weather:
+    phrases:
+      - weather
+      - temperature
+  joke:
+    phrases:
+      - joke
+      - funny
+  fallback:
+    phrases: []

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "compilerOptions": {
+    "target": "ES2020",
+    "module": "commonjs",
+    "declaration": true,
+    "outDir": "dist",
+    "strict": true,
+    "esModuleInterop": true
+  },
+  "include": ["src"]
+}


### PR DESCRIPTION
## Summary
- add a simple FSM engine that reads YAML flows
- define example flow with weather, joke, and fallback intents
- configure tsconfig and dependencies for Node + TypeScript

## Testing
- `npm install`
- `npx tsc`

------
https://chatgpt.com/codex/tasks/task_e_685336566e5c8322b5849a7c59d72a65