### PR TITLE
Implement JSON validation

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
-# a
+# AngoraNet
+
+This repository contains a minimal Flask application exposing a `/messages` endpoint.
+
+Both **POST** and **PUT** requests to `/messages` must send JSON payloads and include the header `Content-Type: application/json`.
+
+Example using `curl`:
+
+```bash
+curl -X PUT http://localhost:5000/messages \
+     -H 'Content-Type: application/json' \
+     -d '{"content": "hello"}'
+```

--- a/angoranet/__init__.py
+++ b/angoranet/__init__.py
@@ -1,0 +1,23 @@
+from flask import Flask, request, jsonify, abort
+
+app = Flask(__name__)
+
+@app.route('/messages', methods=['POST', 'PUT'])
+def handle_post():
+    """Handle POST and PUT requests for message resources."""
+    # Validate JSON input
+    if not request.is_json:
+        return (
+            jsonify(error='Request body must be JSON and use Content-Type: application/json'),
+            400,
+        )
+
+    data = request.get_json()
+    if 'content' not in data:
+        abort(400, description='"content" field is required')
+
+    if request.method == 'POST':
+        return jsonify(status='created', content=data['content']), 201
+
+    # PUT branch
+    return jsonify(status='updated', content=data['content']), 200

--- a/tests/test_handle_post.py
+++ b/tests/test_handle_post.py
@@ -1,0 +1,23 @@
+import pytest
+from angoranet import app
+
+@pytest.fixture
+def client():
+    app.config['TESTING'] = True
+    with app.test_client() as client:
+        yield client
+
+def test_put_requires_json(client):
+    res = client.put('/messages', data='notjson', headers={'Content-Type': 'text/plain'})
+    assert res.status_code == 400
+    assert b'JSON' in res.data
+
+def test_put_requires_content_field(client):
+    res = client.put('/messages', json={'foo': 'bar'})
+    assert res.status_code == 400
+    assert b'content' in res.data
+
+def test_put_success(client):
+    res = client.put('/messages', json={'content': 'hello'})
+    assert res.status_code == 200
+    assert res.get_json()['content'] == 'hello'


### PR DESCRIPTION
## Summary
- create angoranet package with Flask `handle_post`
- validate JSON payloads for POST & PUT
- document JSON requirement in README
- add tests for PUT validation

## Testing
- `python -m pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_6853377bb2c4832281518bf09baf39d5