### PR TITLE
Add simple bot engine, adapters and chat UI

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,0 +1,13 @@
+{
+  "name": "a",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "test": "echo \"Error: no test specified\" && exit 1"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs"
+}

--- a/src/api/joke.ts
+++ b/src/api/joke.ts
@@ -1,0 +1,10 @@
+/**
+ * Fetches a single joke from the JokeAPI.
+ */
+export async function getJoke(): Promise<string> {
+  const url = 'https://v2.jokeapi.dev/joke/Any?type=single';
+  const res = await fetch(url);
+  const data = await res.json();
+
+  return data?.joke || 'No joke available.';
+}

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -1,0 +1,18 @@
+/**
+ * Fetches current weather from the Open-Meteo API for a given location.
+ * Defaults to New York City coordinates if none are provided.
+ */
+export async function getWeather(latitude = 40.7128, longitude = -74.0060): Promise<string> {
+  const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current_weather=true`;
+  const res = await fetch(url);
+  const data = await res.json();
+
+  const temp = data?.current_weather?.temperature;
+  const unit = data?.current_weather_units?.temperature || '°C';
+
+  if (temp === undefined) {
+    return 'Unable to retrieve weather.';
+  }
+
+  return `Current temperature: ${temp}${unit}`;
+}

--- a/src/bot/core/engine.ts
+++ b/src/bot/core/engine.ts
@@ -1,0 +1,22 @@
+import { getWeather } from '../../api/weather';
+import { getJoke } from '../../api/joke';
+
+/**
+ * Routes a user input string to the correct intent.
+ * If the input mentions "weather", the weather adapter is called.
+ * If the input mentions "joke", the joke adapter is called.
+ * Otherwise a simple fallback message is returned.
+ */
+export async function handleInput(input: string): Promise<string> {
+  const text = input.toLowerCase();
+
+  if (text.includes('weather')) {
+    return getWeather();
+  }
+
+  if (text.includes('joke')) {
+    return getJoke();
+  }
+
+  return "I'm not sure how to help with that.";
+}

--- a/src/bot/flows/example.yaml
+++ b/src/bot/flows/example.yaml
@@ -1,0 +1,14 @@
+intents:
+  weather:
+    examples:
+      - "what's the weather"
+      - "weather"
+    action: weather
+  joke:
+    examples:
+      - "tell me a joke"
+      - "joke"
+    action: joke
+  fallback:
+    examples: []
+    action: fallback

--- a/src/ui/components/Chat.tsx
+++ b/src/ui/components/Chat.tsx
@@ -1,0 +1,46 @@
+import { useState } from 'react';
+import { handleInput } from '../../bot/core/engine';
+
+interface Message {
+  from: 'user' | 'bot';
+  text: string;
+}
+
+export function Chat() {
+  const [history, setHistory] = useState<Message[]>([]);
+  const [input, setInput] = useState('');
+
+  async function send() {
+    if (!input.trim()) return;
+    const userMessage: Message = { from: 'user', text: input };
+    setHistory(h => [...h, userMessage]);
+    setInput('');
+
+    const replyText = await handleInput(input);
+    const botMessage: Message = { from: 'bot', text: replyText };
+    setHistory(h => [...h, botMessage]);
+  }
+
+  return (
+    <div className="p-4 max-w-md mx-auto">
+      <div className="space-y-2 mb-4">
+        {history.map((m, i) => (
+          <div key={i} className={m.from === 'bot' ? 'text-blue-600' : ''}>
+            <strong>{m.from === 'bot' ? 'Bot' : 'You'}:</strong> {m.text}
+          </div>
+        ))}
+      </div>
+      <div className="flex space-x-2">
+        <input
+          className="flex-1 border rounded p-2"
+          value={input}
+          onChange={e => setInput(e.target.value)}
+          onKeyDown={e => e.key === 'Enter' && send()}
+        />
+        <button className="bg-blue-500 text-white px-4 py-2 rounded" onClick={send}>
+          Send
+        </button>
+      </div>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- implement basic intent routing engine
- add YAML flow definition for weather/joke/fallback
- provide adapters for Open-Meteo and JokeAPI
- create simple React chat component

## Testing
- `npm test` *(fails: Error: no test specified)*

------
https://chatgpt.com/codex/tasks/task_e_685336612a488322b685183664568a9e