### PR TITLE
Implement simple app routing

### DIFF
--- a/my-app/src/Chat.tsx
+++ b/my-app/src/Chat.tsx
@@ -14,7 +14,11 @@ async function handleInput(input: string): Promise<string> {
     return data.joke as string;
   }
 
-  return "I'm not sure how to help with that.";
+  if (text.includes('uber')) {
+    return 'Requesting a ride via Uber...';
+  }
+
+  return "Sorry I can't do that right now.";
 }
 
 interface Message {

--- a/src/bot/core/apps.ts
+++ b/src/bot/core/apps.ts
@@ -1,0 +1,27 @@
+export interface App {
+  name: string;
+  keywords: string[];
+  run: (input: string) => Promise<string>;
+}
+
+const apps: App[] = [];
+
+export function registerApp(app: App) {
+  apps.push(app);
+}
+
+export function findApp(text: string): App | null {
+  const lower = text.toLowerCase();
+  return apps.find(app => app.keywords.some(k => lower.includes(k))) || null;
+}
+
+export function initDefaultApps() {
+  if (apps.length) return;
+  registerApp({
+    name: 'uber',
+    keywords: ['uber'],
+    async run() {
+      return 'Requesting a ride via Uber...';
+    },
+  });
+}

--- a/src/bot/core/engine.ts
+++ b/src/bot/core/engine.ts
@@ -1,5 +1,6 @@
 import { getWeather } from '../../api/weather';
 import { getJoke } from '../../api/joke';
+import { findApp, initDefaultApps } from './apps';
 
 /**
  * Routes a user input string to the correct intent.
@@ -10,6 +11,8 @@ import { getJoke } from '../../api/joke';
 export async function handleInput(input: string): Promise<string> {
   const text = input.toLowerCase();
 
+  initDefaultApps();
+
   if (text.includes('weather')) {
     return getWeather();
   }
@@ -18,5 +21,10 @@ export async function handleInput(input: string): Promise<string> {
     return getJoke();
   }
 
-  return "I'm not sure how to help with that.";
+  const app = findApp(text);
+  if (app) {
+    return app.run(text);
+  }
+
+  return "Sorry I can't do that right now.";
 }


### PR DESCRIPTION
## Summary
- add basic `App` registry with default Uber app
- route user input to registered apps in the engine
- update chat UI to support Uber requests

## Testing
- `npm run build`
- `cd my-app && npm run build`
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_685692b3e0608322b6c55e33e48f9c58