### PR TITLE
Implement simple CLI note tool

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 dist/
+notes.json

--- a/README.md
+++ b/README.md
@@ -44,6 +44,21 @@ pnpm dev
 
 Run `npm run build` to compile the backend to `dist/`.
 
+### Notes CLI
+
+You can keep quick text notes directly from the command line:
+
+```bash
+# add a note with optional tags
+npm run note -- add "Investigate async support" --tags dev,todo
+
+# list all notes (or only those with matching tags)
+npm run note -- list --tags todo
+
+# search notes by text and optional tags
+npm run note -- search "investigate" --tags dev
+```
+
 ## Examples
 
 A simple p5.js demo is available in `examples/p5-spiral`. Open `index.html` in a web browser to see the animated spiral.

--- a/package-lock.json
+++ b/package-lock.json
@@ -13,6 +13,7 @@
         "node-fetch": "^3.3.2"
       },
       "devDependencies": {
+        "@types/node": "^24.0.3",
         "ts-node": "^10.9.1",
         "typescript": "^5.3.3"
       }

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "scripts": {
     "build": "tsc -p .",
     "start": "node dist/server.js",
-    "dev": "ts-node src/server.ts"
+    "dev": "ts-node src/server.ts",
+    "note": "ts-node src/cli/note.ts"
   },
   "dependencies": {
     "@types/express": "^5.0.3",
@@ -13,6 +14,7 @@
     "node-fetch": "^3.3.2"
   },
   "devDependencies": {
+    "@types/node": "^24.0.3",
     "ts-node": "^10.9.1",
     "typescript": "^5.3.3"
   }

--- a/src/cli/note.ts
+++ b/src/cli/note.ts
@@ -1,0 +1,92 @@
+import fs from 'fs';
+import path from 'path';
+
+interface Note {
+  time: string;
+  text: string;
+  tags?: string[];
+}
+
+const notesPath = path.resolve(__dirname, '../../notes.json');
+
+function loadNotes(): Note[] {
+  if (!fs.existsSync(notesPath)) return [];
+  const raw = fs.readFileSync(notesPath, 'utf8');
+  try {
+    return JSON.parse(raw) as Note[];
+  } catch {
+    return [];
+  }
+}
+
+function saveNotes(notes: Note[]) {
+  fs.writeFileSync(notesPath, JSON.stringify(notes, null, 2));
+}
+
+function list(notes: Note[], tags: string[] = []) {
+  if (!notes.length) {
+    console.log('No notes yet.');
+    return;
+  }
+  const filtered = tags.length
+    ? notes.filter(n => n.tags?.some(t => tags.includes(t)))
+    : notes;
+  for (const n of filtered) {
+    const tagStr = n.tags && n.tags.length ? ` [${n.tags.join(',')}]` : '';
+    console.log(`${n.time} - ${n.text}${tagStr}`);
+  }
+}
+
+function add(text: string, tags: string[] = []) {
+  const notes = loadNotes();
+  notes.push({ time: new Date().toISOString(), text, tags });
+  saveNotes(notes);
+  console.log('Note saved.');
+}
+
+function search(term: string, tags: string[] = []) {
+  const notes = loadNotes();
+  const lower = term.toLowerCase();
+  const matches = notes.filter(n => n.text.toLowerCase().includes(lower));
+  list(matches, tags);
+}
+
+function parseTags(args: string[]): string[] {
+  const idx = args.indexOf('--tags');
+  if (idx === -1) return [];
+  const tagArg = args[idx + 1] || '';
+  args.splice(idx, 2);
+  return tagArg.split(',').map(t => t.trim()).filter(Boolean);
+}
+
+const [,, command, ...rest] = process.argv;
+
+switch (command) {
+  case 'add': {
+    const tags = parseTags(rest);
+    const text = rest.join(' ').trim();
+    if (!text) {
+      console.error('Usage: note add <text> [--tags tag1,tag2]');
+      process.exit(1);
+    }
+    add(text, tags);
+    break;
+  }
+  case 'list': {
+    const tags = parseTags(rest);
+    list(loadNotes(), tags);
+    break;
+  }
+  case 'search': {
+    const tags = parseTags(rest);
+    const term = rest.join(' ').trim();
+    if (!term) {
+      console.error('Usage: note search <term> [--tags tag1,tag2]');
+      process.exit(1);
+    }
+    search(term, tags);
+    break;
+  }
+  default:
+    console.log('Usage: note <add|list|search> [text] [--tags t1,t2]');
+}


### PR DESCRIPTION
## Summary
- add a basic `note` CLI for appending/listing/searching notes
- ignore `notes.json` runtime data
- include `@types/node` for TypeScript builds
- allow tagging and tag-based search in note CLI
- document note usage in README

## Testing
- `npm run build`
- `npm run note -- list`
- `npm run note -- add "hello world"`
- `npm run note -- search "hello"`
- `npm run note -- add "tagged note" --tags tag1,tag2`
- `npm run note -- list --tags tag1`


------
https://chatgpt.com/codex/tasks/task_e_685892b88698832280550a6af5521fdd