### PR TITLE
Improve API error handling

### DIFF
--- a/src/api/joke.ts
+++ b/src/api/joke.ts
@@ -5,8 +5,15 @@ import fetch from 'node-fetch';
  */
 export async function getJoke(): Promise<string> {
   const url = 'https://v2.jokeapi.dev/joke/Any?type=single';
-  const res = await fetch(url);
-  const data: any = await res.json();
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error('Unable to fetch joke.');
+    }
+    const data: any = await res.json();
 
-  return data?.joke || 'No joke available.';
+    return data?.joke || 'No joke available.';
+  } catch {
+    throw new Error('Unable to fetch joke.');
+  }
 }

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -6,15 +6,22 @@ import fetch from 'node-fetch';
  */
 export async function getWeather(latitude = 40.7128, longitude = -74.0060): Promise<string> {
   const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current_weather=true`;
-  const res = await fetch(url);
-  const data: any = await res.json();
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error('Unable to retrieve weather.');
+    }
+    const data: any = await res.json();
 
-  const temp = data?.current_weather?.temperature;
-  const unit = data?.current_weather_units?.temperature || '°C';
+    const temp = data?.current_weather?.temperature;
+    const unit = data?.current_weather_units?.temperature || '°C';
 
-  if (temp === undefined) {
-    return 'Unable to retrieve weather.';
+    if (temp === undefined) {
+      throw new Error('Unable to retrieve weather.');
+    }
+
+    return `Current temperature: ${temp}${unit}`;
+  } catch {
+    throw new Error('Unable to retrieve weather.');
   }
-
-  return `Current temperature: ${temp}${unit}`;
 }

--- a/src/server.ts
+++ b/src/server.ts
@@ -10,7 +10,8 @@ app.get('/api/joke', async (_, res) => {
     const joke = await getJoke();
     res.json({ joke });
   } catch (err) {
-    res.status(500).json({ error: 'Failed to fetch joke' });
+    const message = err instanceof Error ? err.message : 'Failed to fetch joke';
+    res.status(500).json({ error: message });
   }
 });
 
@@ -21,7 +22,8 @@ app.get('/api/weather', async (req, res) => {
     const weather = await getWeather(lat, lon);
     res.json({ weather });
   } catch (err) {
-    res.status(500).json({ error: 'Failed to fetch weather' });
+    const message = err instanceof Error ? err.message : 'Failed to fetch weather';
+    res.status(500).json({ error: message });
   }
 });
 


### PR DESCRIPTION
## Summary
- handle errors from JokeAPI and Open-Meteo
- forward error messages from `getJoke` and `getWeather`

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685839d4c80883228dc808ffb233065a