### PR TITLE
Configure API proxy in Vite

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,9 @@ cd my-app
 pnpm install
 pnpm dev
 ```
+The Vite development server proxies requests starting with `/api` to
+`http://localhost:3000`, so make sure the backend is running with
+`npm run dev` in another terminal.
 
 Run `npm run build` to compile the backend to `dist/`.
 

--- a/my-app/vite.config.ts
+++ b/my-app/vite.config.ts
@@ -4,4 +4,9 @@ import react from '@vitejs/plugin-react'
 // https://vite.dev/config/
 export default defineConfig({
   plugins: [react()],
+  server: {
+    proxy: {
+      '/api': 'http://localhost:3000',
+    },
+  },
 })


### PR DESCRIPTION
## Summary
- add `/api` proxy to the Vite dev server
- document proxy behaviour in the main README

## Testing
- `pnpm lint` *(fails: Cannot find package '@eslint/js')*
- `npm test` *(fails: Missing script "test")*

------
https://chatgpt.com/codex/tasks/task_e_685839d33904832290819114df4cd18a