### PR TITLE
Reuse backend handleInput

### DIFF
--- a/my-app/src/Chat.tsx
+++ b/my-app/src/Chat.tsx
@@ -1,24 +1,13 @@
 import { useState } from 'react';
-async function handleInput(input: string): Promise<string> {
-  const text = input.toLowerCase();
 
-  if (text.includes('weather')) {
-    const res = await fetch('/api/weather');
-    const data = await res.json();
-    return data.weather as string;
-  }
-
-  if (text.includes('joke')) {
-    const res = await fetch('/api/joke');
-    const data = await res.json();
-    return data.joke as string;
-  }
-
-  if (text.includes('uber')) {
-    return 'Requesting a ride via Uber...';
-  }
-
-  return "Sorry I can't do that right now.";
+async function handleInput(text: string): Promise<string> {
+  const res = await fetch('/api/handle', {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify({ text }),
+  });
+  const data = await res.json();
+  return data.reply as string;
 }
 
 interface Message {

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,8 +1,10 @@
 import express from 'express';
 import { getJoke } from './api/joke';
 import { getWeather } from './api/weather';
+import { handleInput } from './bot/core/engine';
 
 const app = express();
+app.use(express.json());
 const port = process.env.PORT || 3000;
 
 app.get('/api/joke', async (_, res) => {
@@ -22,6 +24,20 @@ app.get('/api/weather', async (req, res) => {
     res.json({ weather });
   } catch (err) {
     res.status(500).json({ error: 'Failed to fetch weather' });
+  }
+});
+
+app.post('/api/handle', async (req, res) => {
+  const text = req.body?.text;
+  if (typeof text !== 'string') {
+    res.status(400).json({ error: 'Missing text' });
+    return;
+  }
+  try {
+    const reply = await handleInput(text);
+    res.json({ reply });
+  } catch (err) {
+    res.status(500).json({ error: 'Failed to handle input' });
   }
 });
 


### PR DESCRIPTION
## Summary
- create `/api/handle` endpoint that uses the bot engine
- call new endpoint from the React chat UI

## Testing
- `npm run build`

------
https://chatgpt.com/codex/tasks/task_e_685839ca19f883229b25638c25f64796