### PR TITLE
Handle unreachable APIs in joke and weather fetches

### DIFF
--- a/src/api/joke.ts
+++ b/src/api/joke.ts
@@ -4,9 +4,16 @@ import fetch from 'node-fetch';
  * Fetches a single joke from the JokeAPI.
  */
 export async function getJoke(): Promise<string> {
-  const url = 'https://v2.jokeapi.dev/joke/Any?type=single';
-  const res = await fetch(url);
-  const data: any = await res.json();
-
-  return data?.joke || 'No joke available.';
+  const baseUrl = process.env.JOKE_API_BASE_URL || 'https://v2.jokeapi.dev';
+  const url = `${baseUrl.replace(/\/$/, '')}/joke/Any?type=single`;
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    const data: any = await res.json();
+    return data?.joke || 'No joke available.';
+  } catch {
+    return 'Service unreachable.';
+  }
 }

--- a/src/api/weather.ts
+++ b/src/api/weather.ts
@@ -4,17 +4,31 @@ import fetch from 'node-fetch';
  * Fetches current weather from the Open-Meteo API for a given location.
  * Defaults to New York City coordinates if none are provided.
  */
-export async function getWeather(latitude = 40.7128, longitude = -74.0060): Promise<string> {
-  const url = `https://api.open-meteo.com/v1/forecast?latitude=${latitude}&longitude=${longitude}&current_weather=true`;
-  const res = await fetch(url);
-  const data: any = await res.json();
+export async function getWeather(
+  latitude = 40.7128,
+  longitude = -74.0060
+): Promise<string> {
+  const baseUrl =
+    process.env.WEATHER_API_BASE_URL ||
+    'https://api.open-meteo.com/v1/forecast';
+  const url = `${baseUrl}?latitude=${latitude}&longitude=${longitude}&current_weather=true`;
 
-  const temp = data?.current_weather?.temperature;
-  const unit = data?.current_weather_units?.temperature || '°C';
+  try {
+    const res = await fetch(url);
+    if (!res.ok) {
+      throw new Error(`Request failed with status ${res.status}`);
+    }
+    const data: any = await res.json();
 
-  if (temp === undefined) {
-    return 'Unable to retrieve weather.';
+    const temp = data?.current_weather?.temperature;
+    const unit = data?.current_weather_units?.temperature || '°C';
+
+    if (temp === undefined) {
+      return 'Unable to retrieve weather.';
+    }
+
+    return `Current temperature: ${temp}${unit}`;
+  } catch {
+    return 'Service unreachable.';
   }
-
-  return `Current temperature: ${temp}${unit}`;
 }


### PR DESCRIPTION
## Summary
- improve `getJoke` and `getWeather` to handle fetch errors
- support API base URLs via environment variables

## Testing
- `npm install`
- `npm run build`


------
https://chatgpt.com/codex/tasks/task_e_685839c7fd208322a2c592481383bc71