### PR TITLE
Implement ContinuityCore and update tests

### DIFF
--- a/src/bot/core/continuity.ts
+++ b/src/bot/core/continuity.ts
@@ -1,0 +1,77 @@
+// ContinuityCore implements basic in-memory persistence for conversation patterns.
+// This is a lightweight placeholder to illustrate how such a module could work.
+
+export type Vector = number[];
+
+interface MemoryItem {
+  vector: Vector;
+  pattern: string;
+  salience: number;
+}
+
+const memoryStore: MemoryItem[] = [];
+const identityMap = new Map<string, MemoryItem>();
+
+/**
+ * Convert a conversation pattern string into a numeric vector.
+ * Here we simply encode word lengths as an example.
+ */
+export function observe(pattern: string): Vector {
+  return pattern.split(/\s+/).map(w => w.length);
+}
+
+/**
+ * Assess emotional, logical or contextual relevance.
+ * This returns a simple average length score.
+ */
+export function evaluate_salience(vector: Vector): number {
+  if (!vector.length) return 0;
+  const sum = vector.reduce((a, b) => a + b, 0);
+  return sum / vector.length;
+}
+
+const SALIENCE_THRESHOLD = 4;
+
+/**
+ * Store the vector as a memory item if its salience exceeds the threshold.
+ */
+export function commit_to_memory(vector: Vector) {
+  const salience = evaluate_salience(vector);
+  if (salience >= SALIENCE_THRESHOLD) {
+    memoryStore.push({ vector, salience, pattern: vector.join(' ') });
+  }
+}
+
+/**
+ * Map the vector to an identity anchor for future association.
+ */
+export function link_to_identity(vector: Vector) {
+  const key = vector.join('-');
+  identityMap.set(key, { vector, salience: evaluate_salience(vector), pattern: key });
+}
+
+/**
+ * Combine the current identity with new data to allow gradual change.
+ */
+export function reflect_on_drift<T>(current_identity: T, new_data: Partial<T>): T {
+  return { ...current_identity, ...new_data } as T;
+}
+
+/**
+ * Reorder memory items by salience. This simulates index maintenance.
+ */
+export function auto_update() {
+  memoryStore.sort((a, b) => b.salience - a.salience);
+}
+
+/**
+ * Produce a context string incorporating the most salient memory, if any.
+ */
+export function reconstruct_context(user_prompt: string): string {
+  const top = memoryStore[0];
+  if (top) {
+    return `${user_prompt}\nRelated memory: ${top.pattern}`;
+  }
+  return user_prompt;
+}
+

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -16,6 +16,7 @@ describe('API endpoints', () => {
 
   test('/api/joke returns joke json', async () => {
     mockedFetch.mockResolvedValue({
+      ok: true,
       json: async () => ({ joke: 'Funny' }),
     } as any);
 
@@ -26,6 +27,7 @@ describe('API endpoints', () => {
 
   test('/api/weather returns weather json', async () => {
     mockedFetch.mockResolvedValue({
+      ok: true,
       json: async () => ({
         current_weather: { temperature: 20 },
         current_weather_units: { temperature: '°C' },


### PR DESCRIPTION
## Summary
- add `ContinuityCore` module implementing memory helpers
- adjust tests to mock HTTP success status

## Testing
- `npm install`
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_685ad8a461708322b7641a0b8d13a9ce