### PR TITLE
Add FOIA letter API

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,9 +20,13 @@ examples/
   workflows/
 ```
 
-The backend exposes two endpoints under `/api` which return a random joke and
-current weather information.  The React application located in `my-app/`
-includes a simple chat UI that calls these endpoints.
+The backend exposes several endpoints under `/api`:
+
+- `/api/joke` returns a random joke.
+- `/api/weather` returns current weather information.
+- `/api/foia` generates a FOIA request letter when provided request details.
+
+The React application located in `my-app/` includes a simple chat UI that calls these endpoints.
 
 Additional capabilities include:
 - Voice input and output powered by the Web Speech API.

--- a/package-lock.json
+++ b/package-lock.json
@@ -10,10 +10,12 @@
       "dependencies": {
         "@types/express": "^5.0.3",
         "express": "^4.21.2",
-        "node-fetch": "^3.3.2"
+        "node-fetch": "^3.3.2",
+        "nodemailer": "^6.9.7"
       },
       "devDependencies": {
         "@types/jest": "^29.5.10",
+        "@types/nodemailer": "^6.4.7",
         "@types/supertest": "^2.0.12",
         "jest": "^29.7.0",
         "supertest": "^6.3.3",
@@ -1269,6 +1271,16 @@
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.8.0"
+      }
+    },
+    "node_modules/@types/nodemailer": {
+      "version": "6.4.17",
+      "resolved": "https://registry.npmjs.org/@types/nodemailer/-/nodemailer-6.4.17.tgz",
+      "integrity": "sha512-I9CCaIp6DTldEg7vyUTZi8+9Vo0hi1/T8gv3C89yk1rSAAzoKQ8H8ki/jBYJSFoH/BisgLP8tkZMlQ91CIquww==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
       }
     },
     "node_modules/@types/qs": {
@@ -4058,6 +4070,15 @@
       "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/nodemailer": {
+      "version": "6.10.1",
+      "resolved": "https://registry.npmjs.org/nodemailer/-/nodemailer-6.10.1.tgz",
+      "integrity": "sha512-Z+iLaBGVaSjbIzQ4pX6XV41HrooLsQ10ZWPUehGmuantvzWoDVBnmsdUcOIDM1t+yPor5pDhVlDESgOMEGxhHA==",
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=6.0.0"
+      }
     },
     "node_modules/normalize-path": {
       "version": "3.0.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,8 @@
   "dependencies": {
     "@types/express": "^5.0.3",
     "express": "^4.21.2",
-    "node-fetch": "^3.3.2"
+    "node-fetch": "^3.3.2",
+    "nodemailer": "^6.9.7"
   },
   "devDependencies": {
     "ts-node": "^10.9.1",
@@ -20,6 +21,7 @@
     "ts-jest": "^29.1.1",
     "@types/jest": "^29.5.10",
     "supertest": "^6.3.3",
-    "@types/supertest": "^2.0.12"
+    "@types/supertest": "^2.0.12",
+    "@types/nodemailer": "^6.4.7"
   }
 }

--- a/src/api/foia.ts
+++ b/src/api/foia.ts
@@ -1,0 +1,29 @@
+export interface FoiaRequestOptions {
+  agency: string;
+  topic: string;
+  dateRange: string;
+  location: string;
+  purpose?: string;
+}
+
+export function generateFoiaLetter(opts: FoiaRequestOptions): string {
+  const { agency, topic, dateRange, location, purpose } = opts;
+  return `Subject: Public Records Request\n\nTo Whom It May Concern,\n\nPursuant to the public records law of ${location}, I respectfully request records related to ${topic} from ${agency} for the period ${dateRange}.\n\n${purpose ? `${purpose}\n\n` : ''}Please provide the materials in electronic format if possible. I look forward to your response within the statutory deadline.\n\nSincerely,\n[Your Name]`;
+}
+
+import nodemailer from 'nodemailer';
+
+export async function sendFoiaEmail(
+  opts: FoiaRequestOptions & { recipient: string; from: string },
+  transportOptions: nodemailer.TransportOptions
+): Promise<void> {
+  const transporter = nodemailer.createTransport(transportOptions);
+  const letter = generateFoiaLetter(opts);
+
+  await transporter.sendMail({
+    from: opts.from,
+    to: opts.recipient,
+    subject: 'Public Records Request',
+    text: letter,
+  });
+}

--- a/src/server.ts
+++ b/src/server.ts
@@ -1,9 +1,12 @@
 import express from 'express';
 import { getJoke } from './api/joke';
 import { getWeather } from './api/weather';
+import { generateFoiaLetter } from './api/foia';
 
 export const app = express();
 const port = process.env.PORT || 3000;
+
+app.use(express.json());
 
 app.get('/api/joke', async (_, res) => {
   try {
@@ -24,6 +27,16 @@ app.get('/api/weather', async (req, res) => {
   } catch (err) {
     const message = err instanceof Error ? err.message : 'Failed to fetch weather';
     res.status(500).json({ error: message });
+  }
+});
+
+app.post('/api/foia', (req, res) => {
+  try {
+    const letter = generateFoiaLetter(req.body);
+    res.json({ letter });
+  } catch (err) {
+    const message = err instanceof Error ? err.message : 'Failed to generate letter';
+    res.status(400).json({ error: message });
   }
 });
 

--- a/tests/api.test.ts
+++ b/tests/api.test.ts
@@ -1,10 +1,20 @@
 import request from 'supertest';
 import { app } from '../src/server';
 import fetch from 'node-fetch';
+import nodemailer from 'nodemailer';
 
 jest.mock('node-fetch', () => ({
   __esModule: true,
   default: jest.fn(),
+}));
+
+jest.mock('nodemailer', () => ({
+  __esModule: true,
+  default: {
+    createTransport: jest.fn().mockReturnValue({
+      sendMail: jest.fn().mockResolvedValue(undefined),
+    }),
+  },
 }));
 
 const mockedFetch = fetch as jest.MockedFunction<typeof fetch>;
@@ -37,5 +47,20 @@ describe('API endpoints', () => {
     const res = await request(app).get('/api/weather');
     expect(res.status).toBe(200);
     expect(res.body).toEqual({ weather: 'Current temperature: 20°C' });
+  });
+
+  test('/api/foia generates letter', async () => {
+    const res = await request(app)
+      .post('/api/foia')
+      .send({
+        agency: 'City Hall',
+        topic: 'budgets',
+        dateRange: '2020-2023',
+        location: 'CA',
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.letter).toContain('City Hall');
+    expect(res.body.letter).toContain('budgets');
   });
 });


### PR DESCRIPTION
## Summary
- generate FOIA request letters via `/api/foia`
- implement letter generator and nodemailer helper
- update API tests
- document new endpoint in README

## Testing
- `npm test`

------
https://chatgpt.com/codex/tasks/task_e_686567112bf483229a3fcc42657fb37c