### PR TITLE
Add .dockerignore to exclude build artifacts

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,5 @@
+node_modules
+dist
+my-app/node_modules
+my-app/dist
+tests


### PR DESCRIPTION
## Summary
- keep Docker image lean by ignoring build artifacts and test folders

## Testing
- `npm test`
- `pytest -q` *(fails: `TestClient` unexpected keyword argument 'app')*

------
https://chatgpt.com/codex/tasks/task_e_687ffe1734bc8322a9b0bf515ab465de